### PR TITLE
remove prereq on Smart::Comments

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -21,7 +21,6 @@ on 'test' => sub {
   requires "IPC::Open3" => "0";
   requires "Moose" => "0";
   requires "Moose::Util::TypeConstraints" => "0";
-  requires "Smart::Comments" => "0";
   requires "Test::CheckDeps" => "0.010";
   requires "Test::Fatal" => "0";
   requires "Test::Moose::More" => "0.014";

--- a/t/blank_namespace.t
+++ b/t/blank_namespace.t
@@ -8,7 +8,7 @@ use Test::Moose::More 0.014;
 use Moose::Util::TypeConstraints 'class_type';
 
 # debugging...
-use Smart::Comments '###';
+#use Smart::Comments '###';
 
 {
     package TestClass;


### PR DESCRIPTION
These should only be used author-side and not for normal user installs.
